### PR TITLE
Add Support for Firefox (#7)

### DIFF
--- a/BrowserSearch/Firefox.cs
+++ b/BrowserSearch/Firefox.cs
@@ -1,0 +1,218 @@
+﻿using Microsoft.Data.Sqlite;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Windows;
+using Wox.Infrastructure;
+using Wox.Plugin;
+using Wox.Plugin.Logger;
+using BrowserInfo = Wox.Plugin.Common.DefaultBrowserInfo;
+
+namespace BrowserSearch
+{
+    internal class Firefox : IBrowser
+    {
+        private readonly string _userDataDir;
+        private readonly Dictionary<string, FirefoxProfile> _profiles = [];
+        private readonly string? _selectedProfileName;
+        private readonly List<Result> _history = [];
+        private readonly Dictionary<(string, string), long> _frecencyValues = new();
+
+        public Firefox(string userDataDir, string? profileName)
+        {
+            _userDataDir = userDataDir;
+            _selectedProfileName = profileName;
+        }
+
+        void IBrowser.Init()
+        {
+            CreateProfiles();
+
+            Log.Info($"Loading firefox profile '{_selectedProfileName}'", typeof(Firefox));
+
+            // Load history from all profiles
+            if (_selectedProfileName is null)
+            {
+                foreach (FirefoxProfile profile in _profiles.Values)
+                {
+                    profile.Init(_history, _frecencyValues);
+                }
+
+                return;
+            }
+
+            // Load history from selected profile
+            if (!_profiles.TryGetValue(_selectedProfileName.ToLower(), out FirefoxProfile? selectedProfile))
+            {
+                Log.Error($"Couldn't find profile '{_selectedProfileName}'", typeof(Firefox));
+                MessageBox.Show($"No profile with the name '{_selectedProfileName}' was found.", "BrowserSearch");
+
+                return;
+            }
+            selectedProfile.Init(_history, _frecencyValues);
+        }
+
+        private void CreateProfiles()
+        {
+
+            // _userDataDir contains the path to the ...Roaming\Mozilla\Firefox directory
+
+            // Inside the user data directory, there is a directory called Profiles.
+            // Inside the Profiles directory, there are directories for each profile.
+            // The directory are named with the following format: <random_string>.<profile_name>
+
+            string profilesDir = Path.Join(_userDataDir, "Profiles");
+            string[] profileDirectories = Directory.GetDirectories(profilesDir);
+
+            foreach (string profileDir in profileDirectories)
+            {
+                string profileName = Path.GetFileName(profileDir);
+                int dotIndex = profileName.IndexOf('.');
+                if (dotIndex != -1)
+                {
+                    profileName = profileName.Substring(dotIndex + 1);
+                }
+                Log.Info($"Found profile: '{profileName}'", typeof(Firefox));
+                _profiles[profileName.ToLower()] = new FirefoxProfile(profileDir);
+            }
+        }
+
+        List<Result> IBrowser.GetHistory()
+        {
+            return _history;
+        }
+
+        public int CalculateExtraScore(string query, string title, string url)
+        {
+            // The history entries are stored in the _history list
+            // Those entries have a frecency value
+            // The frecency value is a combination of the amount of times the user visited the page and the time since the last visit
+
+            if (url.Contains(query, StringComparison.InvariantCultureIgnoreCase) || title.Contains(query, StringComparison.InvariantCultureIgnoreCase))
+            {
+                long frecency = _frecencyValues.GetValueOrDefault((url, title), 0);
+                Log.Info($"Frecency for '{title}, {url}': {frecency}", typeof(Firefox));
+                return (int)frecency / 1000;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    }
+
+    internal class FirefoxProfile
+    {
+        private readonly string _path;
+        private bool _initialized;
+        private SqliteConnection? _historyDbConnection;
+
+        public FirefoxProfile(string path)
+        {
+            _path = path;
+        }
+
+        public void Init(List<Result> history, Dictionary<(string, string), long> frecencyValues)
+        {
+            if (_initialized)
+            {
+                return;
+            }
+            Log.Info($"Initializing Firefox profile: '{_path}'", typeof(FirefoxProfile));
+
+            try
+            {
+                CopyDatabases();
+            }
+            catch (FileNotFoundException)
+            {
+                Log.Warn($"Couldn't find database file in '{_path}'", typeof(FirefoxProfile));
+                return;
+            }
+            ArgumentNullException.ThrowIfNull(_historyDbConnection);
+
+            PopulateHistory(history, frecencyValues);
+
+
+            _historyDbConnection.Close();
+            _historyDbConnection.Dispose();
+            _initialized = true;
+
+            Log.Info($"Finished initializing Firefox profile: '{_path}'", typeof(FirefoxProfile));
+        }
+
+        private void CopyDatabases()
+        {
+            string _dirName = _path[(_path.LastIndexOf('\\') + 1)..];
+            string historyCopy = Path.GetTempPath() + @"\BrowserSearch_History_" + _dirName;
+
+            File.Copy(
+                Path.Join(_path, @"\places.sqlite"), historyCopy, true
+            );
+
+            _historyDbConnection = new($"Data Source={historyCopy}");
+        }
+
+        private static SqliteDataReader ExecuteCmd(SqliteConnection connection, SqliteCommand cmd)
+        {
+            cmd.Connection = connection;
+            connection.Open();
+
+            return cmd.ExecuteReader();
+        }
+
+        public void PopulateHistory(List<Result> history, Dictionary<(string, string), long> frecencyValues)
+        {
+            ArgumentNullException.ThrowIfNull(_historyDbConnection);
+
+            // Read the history entries from the database
+            using SqliteCommand historyReadCmd = new("SELECT url, title, frecency FROM moz_places GROUP BY url ORDER BY frecency DESC LIMIT 1000");
+            using SqliteDataReader reader = ExecuteCmd(_historyDbConnection, historyReadCmd);
+
+            // Iterate over the sql results
+            while (reader.Read())
+            {
+                // Make sure there is no System.DBNull value
+                if (reader.IsDBNull(0) || reader.IsDBNull(1) || reader.IsDBNull(2))
+                {
+                    continue;
+                }
+
+
+                string url = (string)reader[0];
+                string title = (string)reader[1];
+                long frecency = (long)reader[2];
+
+                // Add the frecency value to the frecencyValues dictionary
+                frecencyValues[(url, title)] = frecency;
+
+
+                // Create a new Wox Result object and add it to the history list
+                Result result = new()
+                {
+                    QueryTextDisplay = url, // The text that will be displayed in the search box
+                    Title = title, // The title of the result
+                    SubTitle = url, // The subtitle of the result
+                    IcoPath = BrowserInfo.IconPath, // The icon that will be displayed next to the result
+                    Action = action => // The action that will be executed when the result is selected
+                    {
+                        // Open URL in default browser
+                        if (!Helper.OpenInShell(url))
+                        {
+                            Log.Error($"Couldn't open '{url}'", typeof(FirefoxProfile));
+                            return false;
+                        }
+
+                        return true;
+                    },
+                };
+
+                history.Add(result);
+            }
+            history.Reverse();
+
+            Log.Info($"Added {history.Count} history entries", typeof(FirefoxProfile));
+        }
+    }
+}

--- a/BrowserSearch/Firefox.cs
+++ b/BrowserSearch/Firefox.cs
@@ -210,7 +210,8 @@ namespace BrowserSearch
 
                 history.Add(result);
             }
-            history.Reverse();
+            history.Reverse(); // Reversing puts the highest frecency values to the end
+            // This way, the highest frecency values will be the first to be displayed in the search results when the user input is vague
 
             Log.Info($"Added {history.Count} history entries", typeof(FirefoxProfile));
         }

--- a/BrowserSearch/Firefox.cs
+++ b/BrowserSearch/Firefox.cs
@@ -92,7 +92,6 @@ namespace BrowserSearch
             if (url.Contains(query, StringComparison.InvariantCultureIgnoreCase) || title.Contains(query, StringComparison.InvariantCultureIgnoreCase))
             {
                 long frecency = _frecencyValues.GetValueOrDefault((url, title), 0);
-                Log.Info($"Frecency for '{title}, {url}': {frecency}", typeof(Firefox));
                 return (int)frecency / 1000;
             }
             else
@@ -212,8 +211,6 @@ namespace BrowserSearch
             }
             history.Reverse(); // Reversing puts the highest frecency values to the end
             // This way, the highest frecency values will be the first to be displayed in the search results when the user input is vague
-
-            Log.Info($"Added {history.Count} history entries", typeof(FirefoxProfile));
         }
     }
 }

--- a/BrowserSearch/Firefox.cs
+++ b/BrowserSearch/Firefox.cs
@@ -167,7 +167,7 @@ namespace BrowserSearch
             ArgumentNullException.ThrowIfNull(_historyDbConnection);
 
             // Read the history entries from the database
-            using SqliteCommand historyReadCmd = new("SELECT url, title, frecency FROM moz_places GROUP BY url ORDER BY frecency DESC LIMIT 1000");
+            using SqliteCommand historyReadCmd = new("SELECT url, title, frecency FROM moz_places GROUP BY url ORDER BY frecency DESC"); // Limiting here is possible
             using SqliteDataReader reader = ExecuteCmd(_historyDbConnection, historyReadCmd);
 
             // Iterate over the sql results

--- a/BrowserSearch/Main.cs
+++ b/BrowserSearch/Main.cs
@@ -76,17 +76,20 @@ namespace Community.Powertoys.Run.Plugin.BrowserSearch
 
         public void UpdateSettings(PowerLauncherPluginSettings settings)
         {
-            _maxResults = (int)(settings?.AdditionalOptions?.FirstOrDefault(x => x.Key == MaxResults)?.NumberValue ?? 15);
+            var GetSetting = (string key) =>
+            {
+                var target = settings.AdditionalOptions.FirstOrDefault((set) =>
+                {
+                    return set.Key == key;
+                });
+                return target!;
+            };
 
-            PluginAdditionalOption? profile = settings?.AdditionalOptions?.FirstOrDefault(x => x.Key == SingleProfile);
-            if (profile is not null && profile.TextValue?.Length > 0)
-            {
-                _selectedProfileName = profile.TextValue;
-            }
-            else
-            {
-                _selectedProfileName = null;
-            }
+            PluginAdditionalOption maxResults = GetSetting(MaxResults);
+            PluginAdditionalOption singleProfile = GetSetting(SingleProfile);
+
+            _maxResults = (int)maxResults.NumberValue;
+            _selectedProfileName = singleProfile.TextValue;
         }
 
         private void InitDefaultBrowser()

--- a/BrowserSearch/Main.cs
+++ b/BrowserSearch/Main.cs
@@ -110,6 +110,7 @@ namespace Community.Powertoys.Run.Plugin.BrowserSearch
 
             _defaultBrowser = null;
             string localappdata = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string roamingappdata = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
             switch (BrowserInfo.Name)
             {
@@ -184,6 +185,11 @@ namespace Community.Powertoys.Run.Plugin.BrowserSearch
                 case "Wavebox":
                     _defaultBrowser = new Chromium(
                         Path.Join(localappdata, @"WaveboxApp\User Data"), _selectedProfileName
+                    );
+                    break;
+                case "Firefox":
+                    _defaultBrowser = new Firefox(
+                        Path.Join(roamingappdata, @"Mozilla\Firefox"), _selectedProfileName
                     );
                     break;
                 default:

--- a/BrowserSearch/Main.cs
+++ b/BrowserSearch/Main.cs
@@ -76,20 +76,17 @@ namespace Community.Powertoys.Run.Plugin.BrowserSearch
 
         public void UpdateSettings(PowerLauncherPluginSettings settings)
         {
-            var GetSetting = (string key) =>
+            _maxResults = (int)(settings?.AdditionalOptions?.FirstOrDefault(x => x.Key == MaxResults)?.NumberValue ?? 15);
+
+            PluginAdditionalOption? profile = settings?.AdditionalOptions?.FirstOrDefault(x => x.Key == SingleProfile);
+            if (profile is not null && profile.TextValue?.Length > 0)
             {
-                var target = settings.AdditionalOptions.FirstOrDefault((set) =>
-                {
-                    return set.Key == key;
-                });
-                return target!;
-            };
-
-            PluginAdditionalOption maxResults = GetSetting(MaxResults);
-            PluginAdditionalOption singleProfile = GetSetting(SingleProfile);
-
-            _maxResults = (int)maxResults.NumberValue;
-            _selectedProfileName = singleProfile.TextValue;
+                _selectedProfileName = profile.TextValue;
+            }
+            else
+            {
+                _selectedProfileName = null;
+            }
         }
 
         private void InitDefaultBrowser()

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It reads your default browser's history, allowing you to search its entries and 
 * Arc
 * Brave
 * Google Chrome
+* Firefox
 * Microsoft Edge (Chromium version)
 * Thorium
 * Vivaldi Browser

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,17 @@
+@echo off
+
+dotnet build %cd%\BrowserSearch.sln /target:BrowserSearch /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary /p:Configuration=Release /p:Platform="x64"
+
+set "source=%cd%\BrowserSearch\bin\x64\Release\net8.0-windows"
+set "destination=%LOCALAPPDATA%\Microsoft\PowerToys\PowerToys Run\Plugins\BrowserSearch"
+
+if exist "%destination%" (
+  echo Removing existing directory...
+  rmdir /s /q "%destination%"
+)
+
+echo Moving directory...
+move "%source%" "%destination%"
+
+echo Move completed.
+pause


### PR DESCRIPTION
Hey there, thank you for this great plugin!

Closes #7 

I saw that there was no public progress on the Firefox support so I added it myself.
Some information:
- Firefox profiles are just directory names with the format `{stringId}.{profileName}`.
- The Firefox history is in the `places.sqlite` database. There is a _frecency_ value stored for every history entry which I use for calculating the extra score.

This PR also includes two additional changes:
1. I noticed the plugin additional options were not working at all. Changing them in PowerToys had no effect. I added a fix for this by looking at how a different plugin does it.
2. I added a simple installation script to build the project and add it to PowerToys 