### PR TITLE
Fix broken reference to Microsoft.Data.Sqlite.Core

### DIFF
--- a/BrowserSearch/BrowserSearch.csproj
+++ b/BrowserSearch/BrowserSearch.csproj
@@ -18,7 +18,7 @@
     <Reference Include="Wox.Infrastructure">
       <HintPath>libs\Wox.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Sqlite.Core">
+    <Reference Include="Microsoft.Data.Sqlite">
       <HintPath>libs\Microsoft.Data.Sqlite.dll</HintPath>
     </Reference>
     <Reference Include="PowerToys.Settings.UI.Lib">


### PR DESCRIPTION
Code compiles ok but fails to load into powertoys run, generates runtime exception, was seeing a warning icon in the referenced assemblies pane, but no build errors or warnings. I'm using Powertoys v0.81.1. Everything works great now.